### PR TITLE
Set microservice-specific config params.

### DIFF
--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -14,18 +14,27 @@
 {application, bus, [
     {description,  "Urban bus routing microservice prototype."},
     {vsn,          "0.0.2"},
+    {licenses,     ["MIT License"]},
+    {links,        []},
+    {modules,      []},
     {registered,   []},
-    {mod, {
-        bus_app,   []}
-    },
     {applications, [
         kernel,
         stdlib
     ]},
-    {env,          []},
-    {modules,      []},
-    {licenses,     ["MIT License"]},
-    {links,        []}
+    {mod, {
+        bus_app,   []}
+    },
+    {env,          [
+        {server_port, 8765},
+
+        % Set to "yes" to enable debug logging.
+        {logger_debug_enabled, no},
+
+        {routes_datastore_path_prefix, "./"        },
+        {routes_datastore_path_dir,    "data/"     },
+        {routes_datastore_filename,    "routes.txt"}
+    ]}
 ]}.
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus_app.erl
+++ b/apps/bus/src/bus_app.erl
@@ -36,7 +36,7 @@
 %% @returns The tuple containing the PID of the top supervisor
 %%          and the `State' indicator (defaults to an empty list).
 start(_StartType, _StartArgs) ->
-    io:put_chars(?NEW_LINE ++ ?MSG_WORK_IN_PROGRESS ++ ?NEW_LINE ++ ?NEW_LINE),
+    io:put_chars(?NEW_LINE ?MSG_WORK_IN_PROGRESS ?NEW_LINE ?NEW_LINE),
 
     bus_sup:start_link().
 

--- a/apps/bus/src/bus_app.erl
+++ b/apps/bus/src/bus_app.erl
@@ -38,6 +38,21 @@
 start(_StartType, _StartArgs) ->
     io:put_chars(?NEW_LINE ?MSG_WORK_IN_PROGRESS ?NEW_LINE ?NEW_LINE),
 
+    %% --- Debug output - Begin -----------------------------------------------
+    AppDescription  = element(2, application:get_key(description         )),
+    ServerPort      = element(2, application:get_env(server_port         )),
+    DebugLogEnabled = element(2, application:get_env(logger_debug_enabled)),
+
+    Datastore = element(2, application:get_env(routes_datastore_path_prefix))
+             ++ element(2, application:get_env(routes_datastore_path_dir   ))
+             ++ element(2, application:get_env(routes_datastore_filename   )),
+
+    io:put_chars(                AppDescription   ++ ?NEW_LINE          ),
+    io:put_chars(integer_to_list(ServerPort     ) ++ ?NEW_LINE          ),
+    io:put_chars(   atom_to_list(DebugLogEnabled) ++ ?NEW_LINE          ),
+    io:put_chars(                Datastore        ++ ?NEW_LINE ?NEW_LINE),
+    %% --- Debug output - End -------------------------------------------------
+
     bus_sup:start_link().
 
 %% ----------------------------------------------------------------------------


### PR DESCRIPTION
- Reordering app spec entries and populating the `env` list with the _microservice-specific settings_.
- Retrieving _microservice-specific settings_ from app spec and printing them out for debugging purposes.