### PR TITLE
Process routes one by one and eliminate a route identifier from each of them.

### DIFF
--- a/apps/bus/src/bus_helper.hrl
+++ b/apps/bus/src/bus_helper.hrl
@@ -20,7 +20,10 @@
 %% ----------------------------------------------------------------------------
 
 % Helper constants.
--define(NEW_LINE, "\n").
+-define(EMPTY_STRING,   "").
+-define(SPACE,         " ").
+-define(V_BAR,         "|").
+-define(NEW_LINE,     "\n").
 
 % Common notification messages.
 -define(MSG_WORK_IN_PROGRESS, "This is a work in progress"

--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,7 @@
     {release, {
         bus, "0.0.2"
     }, [
-        bus,
-        sasl
+        bus
     ]},
 
     {include_src, false}

--- a/rebar.config
+++ b/rebar.config
@@ -11,40 +11,19 @@
 % (See the LICENSE file at the top of the source tree.)
 %
 
-{erl_opts, [debug_info]}.
-{deps,     []          }.
-
 {relx, [
     {release, {
         bus, "0.0.2"
-    }, [bus, sasl]},
-
-    {mode, dev},
-
-    % Automatically picked up if the files exist but can be set manually,
-    % which is required if the names aren't exactly sys.config and vm.args:
-    {sys_config, "./config/sys.config"},
-    {vm_args,    "./config/vm.args"   },
-
-    % The .src form of the configuration files
-    % do not require setting RELX_REPLACE_OS_VARS:
-    % {sys_config_src, "./config/sys.config.src"},
-    % {vm_args_src,    "./config/vm.args.src"   },
+    }, [
+        bus,
+        sasl
+    ]},
 
     {include_src, false}
 ]}.
 
 {profiles, [
-    {prod, [
-        {relx, [
-            % prod is the default mode when prod profile is used,
-            % so does not have to be explicitly included like this:
-            {mode, prod}
-
-            % Use minimal mode to exclude ERTS:
-            % {mode, minimal}
-        ]}
-    ]}
+    {prod, []}
 ]}.
 
 % vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Keeping **Rebar3 configuration** as minimal as possible.
- Excluding the **SASL app** from dependencies, for a while.
- Defining some more helper constants.
- Processing routes one by one and eliminating a route identifier from each of them, thus preparing a _distilled_ routes list.