### PR TITLE
Start using the Erlang/OTP standard logging facility.

### DIFF
--- a/apps/bus/src/bus_app.erl
+++ b/apps/bus/src/bus_app.erl
@@ -42,8 +42,8 @@
 %% @returns The tuple containing the PID of the top supervisor
 %%          and the `State' indicator (defaults to an empty list).
 start(_StartType, _StartArgs) ->
-%   io:put_chars(?NEW_LINE ?MSG_WORK_IN_PROGRESS ?NEW_LINE ?NEW_LINE),
-    io:nl(), io:put_chars(?MSG_WORK_IN_PROGRESS), io:nl(), io:nl(),
+    io:put_chars(?MSG_WORK_IN_PROGRESS), io:nl(),
+    logger:info (?MSG_WORK_IN_PROGRESS),
 
     % Getting the application settings.
     Settings = get_settings(),
@@ -64,7 +64,7 @@ start(_StartType, _StartArgs) ->
     end, [], Routes),
 
     %% --- Debug output - Begin -----------------------------------------------
-    io:put_chars(RoutesList ++ ?V_BAR), io:nl(), io:nl(),
+%   io:put_chars(RoutesList ++ ?V_BAR), io:nl(), io:nl(),
     %% --- Debug output - End -------------------------------------------------
 
     bus_sup:start_link().

--- a/config/sys.config
+++ b/config/sys.config
@@ -12,6 +12,30 @@
 %
 
 [
+    {kernel, [
+        {logger, [
+            {handler, default, logger_std_h, #{
+                config => #{
+                    file               => "./log/bus.log",
+                    max_no_bytes       => 204800,
+                    max_no_files       => 10,
+                    compress_on_rotate => true
+                },
+                formatter => {
+                    logger_formatter, #{
+                        template => ["[", time, "][", level, "]  ", msg, "\n"],
+%                                          ^            ^            ^     ^
+%                                          |            |            |     |
+% --- Date and time -----------------------+            |            |     |
+% --- Severity (info, debug, etc.) ---------------------+            |     |
+% --- The logging message itself ------------------------------------+     |
+% --- Newline character ---------------------------------------------------+
+                        time_designator => $|
+                }}
+            }}
+        ]},
+        {logger_level, info}
+    ]},
     {bus, []}
 ].
 


### PR DESCRIPTION
- Configuring **Kernel Logger** to log events as much as closer to those configs used in **Java** and **Clojure** microservice implementations.
- Start logging messages through the specially configured **Kernel Logger**.