### PR TITLE
Log events to the console along with the file-based logging.

### DIFF
--- a/apps/bus/src/bus_app.erl
+++ b/apps/bus/src/bus_app.erl
@@ -42,8 +42,7 @@
 %% @returns The tuple containing the PID of the top supervisor
 %%          and the `State' indicator (defaults to an empty list).
 start(_StartType, _StartArgs) ->
-    io:put_chars(?MSG_WORK_IN_PROGRESS), io:nl(),
-    logger:info (?MSG_WORK_IN_PROGRESS),
+    logger:info(?MSG_WORK_IN_PROGRESS),
 
     % Getting the application settings.
     Settings = get_settings(),
@@ -64,7 +63,7 @@ start(_StartType, _StartArgs) ->
     end, [], Routes),
 
     %% --- Debug output - Begin -----------------------------------------------
-%   io:put_chars(RoutesList ++ ?V_BAR), io:nl(), io:nl(),
+    logger:debug(RoutesList ++ ?V_BAR),
     %% --- Debug output - End -------------------------------------------------
 
     bus_sup:start_link().

--- a/config/sys.config
+++ b/config/sys.config
@@ -14,7 +14,15 @@
 [
     {kernel, [
         {logger, [
-            {handler, default, logger_std_h, #{
+            {handler, default,  logger_std_h, #{
+                formatter => {
+                    logger_formatter, #{
+                        template => ["[", time, "][", level, "]  ", msg, "\n"],
+                        time_designator => $|
+                    }
+                }
+            }},
+            {handler, default_, logger_std_h, #{
                 config => #{
                     file               => "./log/bus.log",
                     max_no_bytes       => 204800,
@@ -31,10 +39,11 @@
 % --- The logging message itself ------------------------------------+     |
 % --- Newline character ---------------------------------------------------+
                         time_designator => $|
-                }}
+                    }
+                }
             }}
         ]},
-        {logger_level, info}
+        {logger_level, debug}
     ]},
     {bus, []}
 ].


### PR DESCRIPTION
- Adding the logger handler config to log events to the console along with the file-based logging.
- Lowering the logger level to `debug`.
- Replacing all `io:put_chars` calls with appropriate logger calls.