### PR TITLE
RESTful-related works | Part I.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+# Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 # =============================================================================
 # An Erlang/OTP application, designed and intended to be run as a microservice,
 # implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+# Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 # =============================================================================
 # An Erlang/OTP application, designed and intended to be run as a microservice,
 # implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ rebar3 tree
 ===> Fetching cowboy v2.9.0
 ===> Fetching cowlib v2.11.0
 ===> Fetching ranch v1.8.0
-└─ bus─0.1.5 (project app)
+└─ bus─0.1.7 (project app)
    └─ cowboy─2.9.0 (hex package)
       ├─ cowlib─2.11.0 (hex package)
       └─ ranch─1.8.0 (hex package)

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus.app.src
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {application, bus, [
     {description,  "Urban bus routing microservice prototype."},
-    {vsn,          "0.1.5"},
+    {vsn,          "0.1.7"},
     {licenses,     ["MIT License"]},
     {links,        []},
     {modules,      []},

--- a/apps/bus/src/bus_app.erl
+++ b/apps/bus/src/bus_app.erl
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus_app.erl
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -14,7 +14,7 @@
 %% ----------------------------------------------------------------------------
 %% @doc The callback module of the application.
 %%
-%% @version 0.1.5
+%% @version 0.1.7
 %% @since   0.0.1
 %% @end
 %% ----------------------------------------------------------------------------

--- a/apps/bus/src/bus_controller.erl
+++ b/apps/bus/src/bus_controller.erl
@@ -52,7 +52,10 @@ startup(Args) ->
 %                                                 ?SAMPLE_ROUTES_FILENAME,
 %               [{mimetypes, cow_mimetypes, all}]
 %           }},
-            {"/", bus_handler, []}
+            {
+                ?SLASH?REST_PREFIX?SLASH?REST_DIRECT, % <== GET /route/direct
+                bus_handler, []
+            }
         ]}
     ]),
 

--- a/apps/bus/src/bus_controller.erl
+++ b/apps/bus/src/bus_controller.erl
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus_controller.erl
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -14,7 +14,7 @@
 %% ----------------------------------------------------------------------------
 %% @doc The controller module of the application.
 %%
-%% @version 0.1.5
+%% @version 0.1.7
 %% @since   0.0.3
 %% @end
 %% ----------------------------------------------------------------------------

--- a/apps/bus/src/bus_handler.erl
+++ b/apps/bus/src/bus_handler.erl
@@ -35,12 +35,24 @@
 %% @param Req   The incoming HTTP request object.
 %% @param State TODO: Provide the description of the `State' param.
 %%
-%% @returns The `ok' tuple containing a new request object
+%% @returns The `cowboy_rest' tuple containing the request object
 %%          along with the state of the request.
+%%          The atom `cowboy_rest' indicates that Cowboy will pick
+%%          the REST handler behavior to operate on requests.
 init(Req, State) ->
     {cowboy_rest, Req, State}.
 
 %% ----------------------------------------------------------------------------
+%% @doc The REST-specific callback to respond to the client
+%%      when one of the `HEAD', `GET', or `OPTIONS' methods is used.
+%%
+%% @param Req   The incoming HTTP request object.
+%% @param State TODO: Provide the description of the `State' param.
+%%
+%% @returns The list of media types the microservice provides when responding
+%%          to the client. The special callback then will be called for any
+%%          appropriate request regarding the corresponding media type:
+%%          `application/json' is currently the only used one.
 content_types_provided(Req, State) ->
     {[{{
         ?MIME_TYPE, ?MIME_SUB_TYPE, % <== content-type: application/json
@@ -48,6 +60,19 @@ content_types_provided(Req, State) ->
     }, to_json}], Req, State}.
 
 %% ----------------------------------------------------------------------------
+%% @doc The so-called `ProvideCallback', used to return the response body.
+%%
+%% @param Req   The incoming HTTP request object.
+%% @param State TODO: Provide the description of the `State' param.
+%%
+%% @returns The body of the response in the JSON representation,
+%%          containing the following properties:
+%%          <ul>
+%%          <li><strong>from</strong> &mdash; The starting bus stop point.</li>
+%%          <li><strong>to</strong>   &mdash; The ending   bus stop point.</li>
+%%          <li><strong>direct</strong> &mdash; The logical indicator
+%%          of the presence of a direct route from `from' to `to'.</li>
+%%          </ul>
 to_json(Req, State) ->
     {<<"{}">>, Req, State}.
 

--- a/apps/bus/src/bus_handler.erl
+++ b/apps/bus/src/bus_handler.erl
@@ -74,6 +74,14 @@ content_types_provided(Req, State) ->
 %%          of the presence of a direct route from `from' to `to'.</li>
 %%          </ul>
 to_json(Req, State) ->
-    {<<"{}">>, Req, State}.
+    #{from := From, to := To} = cowboy_req:match_qs([{from,int},{to,int}],Req),
+
+    logger:debug(?FROM?EQUALS ++ integer_to_list(From) ++ ?SPACE?V_BAR?SPACE
+                   ?TO?EQUALS ++ integer_to_list(To  )),
+
+    {[
+        "{\""?FROM"\":", integer_to_list(From),
+          ",\""?TO"\":", integer_to_list(To  ), "}"
+    ], Req, State}.
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus_handler.erl
+++ b/apps/bus/src/bus_handler.erl
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus_handler.erl
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -14,7 +14,7 @@
 %% ----------------------------------------------------------------------------
 %% @doc The request handler module of the application.
 %%
-%% @version 0.1.5
+%% @version 0.1.7
 %% @since   0.1.0
 %% @end
 %% ----------------------------------------------------------------------------

--- a/apps/bus/src/bus_handler.erl
+++ b/apps/bus/src/bus_handler.erl
@@ -20,7 +20,11 @@
 %% ----------------------------------------------------------------------------
 -module(bus_handler).
 
--export([init/2]).
+-export([
+    init/2,
+    content_types_provided/2,
+    to_json/2
+]).
 
 -include("bus_helper.hrl").
 
@@ -34,10 +38,17 @@
 %% @returns The `ok' tuple containing a new request object
 %%          along with the state of the request.
 init(Req, State) ->
-    Req_ = cowboy_req:reply(?HTTP_200_OK, #{
-        ?HDR_CONTENT_TYPE_N => ?HDR_CONTENT_TYPE_V
-    }, Req),
+    {cowboy_rest, Req, State}.
 
-    {ok, Req_, State}.
+%% ----------------------------------------------------------------------------
+content_types_provided(Req, State) ->
+    {[{{
+        ?MIME_TYPE, ?MIME_SUB_TYPE, % <== content-type: application/json
+        []                          % <== No any params will be accepted.
+    }, to_json}], Req, State}.
+
+%% ----------------------------------------------------------------------------
+to_json(Req, State) ->
+    {<<"{}">>, Req, State}.
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus_helper.hrl
+++ b/apps/bus/src/bus_helper.hrl
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus_helper.hrl
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -14,7 +14,7 @@
 %% ----------------------------------------------------------------------------
 %% @doc The helper header file for the application.
 %%
-%% @version 0.1.5
+%% @version 0.1.7
 %% @since   0.0.1
 %% @end
 %% ----------------------------------------------------------------------------

--- a/apps/bus/src/bus_helper.hrl
+++ b/apps/bus/src/bus_helper.hrl
@@ -25,6 +25,8 @@
 -define(EMPTY_STRING,   "").
 -define(SPACE,         " ").
 -define(V_BAR,         "|").
+-define(SLASH,         "/").
+-define(EQUALS,        "=").
 -define(NEW_LINE,     "\n").
 
 % Common error messages.
@@ -70,8 +72,16 @@
 -define(SAMPLE_ROUTES_PATH_DIR,    "data/"     ).
 -define(SAMPLE_ROUTES_FILENAME,    "routes.txt").
 
+% REST URI path-related constants.
+-define(REST_PREFIX, "route" ).
+-define(REST_DIRECT, "direct").
+
 % HTTP response-related constants.
 -define(MIME_TYPE,     <<"application">>).
 -define(MIME_SUB_TYPE, <<"json">>       ).
+
+% HTTP request parameter names.
+-define(FROM, "from").
+-define(TO,   "to"  ).
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus_helper.hrl
+++ b/apps/bus/src/bus_helper.hrl
@@ -71,8 +71,7 @@
 -define(SAMPLE_ROUTES_FILENAME,    "routes.txt").
 
 % HTTP response-related constants.
--define(HTTP_200_OK,        200                   ).
--define(HDR_CONTENT_TYPE_N, <<"content-type">>    ).
--define(HDR_CONTENT_TYPE_V, <<"application/json">>).
+-define(MIME_TYPE,     <<"application">>).
+-define(MIME_SUB_TYPE, <<"json">>       ).
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus_sup.erl
+++ b/apps/bus/src/bus_sup.erl
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus_sup.erl
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -14,7 +14,7 @@
 %% ----------------------------------------------------------------------------
 %% @doc The supervisor module of the application.
 %%
-%% @version 0.1.5
+%% @version 0.1.7
 %% @since   0.0.1
 %% @end
 %% ----------------------------------------------------------------------------

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,7 @@
 %
 % config/sys.config
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %
 % rebar.config
 % =============================================================================
-% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (Erlang/OTP port). Version 0.1.7
 % =============================================================================
 % An Erlang/OTP application, designed and intended to be run as a microservice,
 % implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {relx, [
     {release, {
-        bus, "0.1.5"
+        bus, "0.1.7"
     }, [
         bus
     ]},


### PR DESCRIPTION
- Replacing HTTP response-related constants required for the plain HTTP handler with those needed for the **REST handler**.
- Converting the plain HTTP handler to the **REST handler**.
- Providing relevant EDoc sections for handler callbacks.
- Adding extra helper constants, REST URI path-related constants, and HTTP request parameter names.
- Setting a dedicated and required, and the only **REST endpoint** to accept **GET requests**.
- Retrieving request params and log them out, then responding to the client with the home-made **JSON structure**, containing them as well.
- Bumping version number to **0.1.7**.